### PR TITLE
feat: Implement MCP server process management

### DIFF
--- a/assistant_core/assistant.py
+++ b/assistant_core/assistant.py
@@ -16,9 +16,17 @@ class Assistant:
 
     def _fetch_all_tools(self):
         all_tools = []
-        for url in self.mcp_server_urls:
+        server_definitions = settings.get_mcp_servers()
+        for server in server_definitions:
+            if not server.get('enabled'):
+                continue
+
+            url = server.get('url')
+            if not url:
+                continue
+
             try:
-                response = requests.get(f"{url}/tools")
+                response = requests.get(f"{url}/tools", timeout=5)
                 response.raise_for_status()
                 server_tools = response.json()
                 for tool_schema in server_tools:

--- a/assistant_core/process_manager.py
+++ b/assistant_core/process_manager.py
@@ -1,0 +1,35 @@
+import subprocess
+import shlex
+from config.settings import settings
+
+class ProcessManager:
+    def __init__(self):
+        self.processes = []
+
+    def start_servers(self):
+        servers = settings.get_mcp_servers()
+        for server in servers:
+            if server.get('enabled') and server.get('command'):
+                try:
+                    command = [server['command']] + shlex.split(server.get('args', ''))
+                    print(f"Starting server '{server['name']}': {' '.join(command)}")
+                    # Use Popen for non-blocking process creation
+                    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+                    self.processes.append(proc)
+                except Exception as e:
+                    print(f"Failed to start server '{server['name']}': {e}")
+
+    def shutdown(self):
+        print("Shutting down all managed server processes...")
+        for proc in self.processes:
+            proc.terminate() # Send SIGTERM
+
+        # Optional: wait for processes to terminate gracefully
+        for proc in self.processes:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                print(f"Process {proc.pid} did not terminate gracefully, killing.")
+                proc.kill() # Send SIGKILL
+
+        print("Shutdown complete.")

--- a/config/settings.py
+++ b/config/settings.py
@@ -34,18 +34,30 @@ class Settings:
         self.save()
 
     def get_mcp_servers(self):
-        return self.get("mcp_servers", [])
+        # Ensure backward compatibility for users with old config
+        servers = self.get("mcp_servers", [])
+        if servers and isinstance(servers[0], str):
+            # Convert old string-based list to new object-based list
+            new_servers = [{"name": f"Server {i+1}", "url": url, "enabled": True, "command": "", "args": ""} for i, url in enumerate(servers)]
+            self.set("mcp_servers", new_servers)
+            return new_servers
+        return servers
 
-    def add_mcp_server(self, url):
+    def add_mcp_server(self, server_definition):
         servers = self.get_mcp_servers()
-        if url not in servers:
-            servers.append(url)
+        servers.append(server_definition)
+        self.set("mcp_servers", servers)
+
+    def update_mcp_server(self, index, server_definition):
+        servers = self.get_mcp_servers()
+        if 0 <= index < len(servers):
+            servers[index] = server_definition
             self.set("mcp_servers", servers)
 
-    def remove_mcp_server(self, url):
+    def remove_mcp_server(self, index):
         servers = self.get_mcp_servers()
-        if url in servers:
-            servers.remove(url)
+        if 0 <= index < len(servers):
+            servers.pop(index)
             self.set("mcp_servers", servers)
 
     def get_api_mode(self):

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -1,19 +1,15 @@
 import tkinter as tk
-from tkinter import simpledialog, messagebox
+from tkinter import ttk, simpledialog, messagebox
 from config.settings import settings
 
 class ApiKeysDialog(simpledialog.Dialog):
     def body(self, master):
         self.title("Manage API Keys")
-
         tk.Label(master, text="OpenAI API Key:").grid(row=0, sticky="w")
-
         self.openai_key_var = tk.StringVar(master)
         self.openai_key_var.set(settings.get_api_key("openai") or "")
-
         self.openai_key_entry = tk.Entry(master, textvariable=self.openai_key_var, width=50)
         self.openai_key_entry.grid(row=0, column=1, padx=5, pady=5)
-
         return self.openai_key_entry
 
     def apply(self):
@@ -22,44 +18,105 @@ class ApiKeysDialog(simpledialog.Dialog):
             settings.set_api_key("openai", new_key)
             messagebox.showinfo("Success", "OpenAI API Key saved.", parent=self)
 
-class MCPManagerDialog(simpledialog.Dialog):
+class ServerEditorDialog(simpledialog.Dialog):
+    def __init__(self, parent, title, server=None):
+        self.server = server or {}
+        super().__init__(parent, title)
+
     def body(self, master):
+        self.title(self.title)
+
+        tk.Label(master, text="Name:").grid(row=0, column=0, sticky="w", padx=5, pady=2)
+        self.name_var = tk.StringVar(master, value=self.server.get("name", ""))
+        self.name_entry = tk.Entry(master, textvariable=self.name_var, width=40)
+        self.name_entry.grid(row=0, column=1, padx=5, pady=2)
+
+        tk.Label(master, text="URL:").grid(row=1, column=0, sticky="w", padx=5, pady=2)
+        self.url_var = tk.StringVar(master, value=self.server.get("url", ""))
+        self.url_entry = tk.Entry(master, textvariable=self.url_var, width=40)
+        self.url_entry.grid(row=1, column=1, padx=5, pady=2)
+
+        tk.Label(master, text="Command:").grid(row=2, column=0, sticky="w", padx=5, pady=2)
+        self.command_var = tk.StringVar(master, value=self.server.get("command", ""))
+        self.command_entry = tk.Entry(master, textvariable=self.command_var, width=40)
+        self.command_entry.grid(row=2, column=1, padx=5, pady=2)
+
+        tk.Label(master, text="Arguments:").grid(row=3, column=0, sticky="w", padx=5, pady=2)
+        self.args_var = tk.StringVar(master, value=self.server.get("args", ""))
+        self.args_entry = tk.Entry(master, textvariable=self.args_var, width=40)
+        self.args_entry.grid(row=3, column=1, padx=5, pady=2)
+
+        self.enabled_var = tk.BooleanVar(master, value=self.server.get("enabled", True))
+        self.enabled_check = tk.Checkbutton(master, text="Enabled", variable=self.enabled_var)
+        self.enabled_check.grid(row=4, column=1, sticky="w", padx=5, pady=5)
+
+        return self.name_entry
+
+    def apply(self):
+        self.result = {
+            "name": self.name_var.get(),
+            "url": self.url_var.get(),
+            "command": self.command_var.get(),
+            "args": self.args_var.get(),
+            "enabled": self.enabled_var.get()
+        }
+
+class MCPManagerDialog(tk.Toplevel):
+    def __init__(self, parent):
+        super().__init__(parent)
         self.title("Manage MCP Servers")
+        self.transient(parent)
+        self.grab_set()
 
-        self.listbox = tk.Listbox(master, width=50)
-        self.listbox.pack(padx=10, pady=10)
-        self.populate_listbox()
+        self.tree = ttk.Treeview(self, columns=("Name", "URL", "Enabled"), show="headings")
+        self.tree.heading("Name", text="Name")
+        self.tree.heading("URL", text="URL")
+        self.tree.heading("Enabled", text="Enabled")
+        self.tree.pack(padx=10, pady=10, fill="both", expand=True)
 
-        btn_frame = tk.Frame(master)
-        self.add_btn = tk.Button(btn_frame, text="Add", command=self.add_server)
-        self.add_btn.pack(side="left", padx=5)
-        self.remove_btn = tk.Button(btn_frame, text="Remove", command=self.remove_server)
-        self.remove_btn.pack(side="left", padx=5)
+        self.populate_tree()
+
+        btn_frame = tk.Frame(self)
+        tk.Button(btn_frame, text="Add", command=self.add_server).pack(side="left", padx=5)
+        tk.Button(btn_frame, text="Edit", command=self.edit_server).pack(side="left", padx=5)
+        tk.Button(btn_frame, text="Remove", command=self.remove_server).pack(side="left", padx=5)
         btn_frame.pack(pady=5)
 
-        return self.listbox # initial focus
+        self.wait_window(self)
 
-    def populate_listbox(self):
-        self.listbox.delete(0, tk.END)
-        for server in settings.get_mcp_servers():
-            self.listbox.insert(tk.END, server)
+    def populate_tree(self):
+        for i in self.tree.get_children():
+            self.tree.delete(i)
+        for i, server in enumerate(settings.get_mcp_servers()):
+            self.tree.insert("", "end", iid=i, values=(server["name"], server["url"], server["enabled"]))
 
     def add_server(self):
-        new_url = simpledialog.askstring("Add Server", "Enter MCP Server URL:", parent=self)
-        if new_url:
-            settings.add_mcp_server(new_url)
-            self.populate_listbox()
+        editor = ServerEditorDialog(self, "Add MCP Server")
+        if editor.result:
+            settings.add_mcp_server(editor.result)
+            self.populate_tree()
+
+    def edit_server(self):
+        selected_item = self.tree.focus()
+        if not selected_item:
+            messagebox.showwarning("No Selection", "Please select a server to edit.", parent=self)
+            return
+
+        index = int(selected_item)
+        server_data = settings.get_mcp_servers()[index]
+
+        editor = ServerEditorDialog(self, "Edit MCP Server", server=server_data)
+        if editor.result:
+            settings.update_mcp_server(index, editor.result)
+            self.populate_tree()
 
     def remove_server(self):
-        selected_index = self.listbox.curselection()
-        if not selected_index:
+        selected_item = self.tree.focus()
+        if not selected_item:
             messagebox.showwarning("No Selection", "Please select a server to remove.", parent=self)
             return
 
-        selected_url = self.listbox.get(selected_index)
-        settings.remove_mcp_server(selected_url)
-        self.populate_listbox()
-
-    def apply(self):
-        # Settings are saved on add/remove, so nothing to do here
-        pass
+        if messagebox.askyesno("Confirm", "Are you sure you want to remove the selected server?", parent=self):
+            index = int(selected_item)
+            settings.remove_mcp_server(index)
+            self.populate_tree()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,16 @@
+import atexit
 from gui.main_window import MainWindow
+from assistant_core.process_manager import ProcessManager
 
 def main():
-    # The MCP server is no longer run locally.
-    # The assistant now connects to external servers.
+    # Initialize and start MCP server processes
+    process_manager = ProcessManager()
+    process_manager.start_servers()
+
+    # Register shutdown hook to terminate servers on exit
+    atexit.register(process_manager.shutdown)
+
+    # Run the GUI
     app = MainWindow()
     app.mainloop()
 


### PR DESCRIPTION
This commit adds a major feature that allows the application to manage the lifecycle of external MCP server processes.

Key changes:
- The configuration system is updated to store detailed server definitions (name, command, args, url, enabled) instead of just URLs.
- A new `ProcessManager` class is introduced to start and stop configured server processes using `subprocess.Popen`.
- The `ProcessManager` is integrated into the application's lifecycle, starting servers on launch and terminating them on exit via `atexit`.
- The 'Manage MCP Servers' UI has been completely overhauled with a `ttk.Treeview` and a dedicated editor dialog to allow full CRUD management of server definitions.
- The `Assistant` is updated to use the new server definition objects from the configuration.