### PR TITLE
fix: Resolve subprocess deadlock and improve argument parsing

### DIFF
--- a/assistant_core/process_manager.py
+++ b/assistant_core/process_manager.py
@@ -11,10 +11,20 @@ class ProcessManager:
         for server in servers:
             if server.get('enabled') and server.get('command'):
                 try:
-                    command = [server['command']] + shlex.split(server.get('args', ''))
+                    # Handle args whether they are a string or a list
+                    args_raw = server.get('args')
+                    if isinstance(args_raw, str):
+                        args_list = shlex.split(args_raw)
+                    elif isinstance(args_raw, list):
+                        args_list = args_raw
+                    else:
+                        args_list = []
+
+                    command = [server['command']] + args_list
                     print(f"Starting server '{server['name']}': {' '.join(command)}")
                     # Use Popen for non-blocking process creation
-                    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+                    # Redirect stdout/stderr to DEVNULL to prevent pipe deadlocks
+                    proc = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                     self.processes.append(proc)
                 except Exception as e:
                     print(f"Failed to start server '{server['name']}': {e}")


### PR DESCRIPTION
This commit fixes a critical bug where the application would freeze when launching a managed MCP server process that produces output. It also improves the robustness of server argument parsing.

Key changes:
- In `ProcessManager`, the `subprocess.Popen` call now redirects `stdout` and `stderr` to `DEVNULL`. This prevents the parent process from deadlocking while waiting for pipes that were never read.
- The argument parsing logic in `ProcessManager` is updated to correctly handle the `args` field whether it is a string (from the UI) or a list (from a manual `config.json` edit).