### PR TITLE
feat: Implement LLM provider selection

### DIFF
--- a/assistant_core/assistant.py
+++ b/assistant_core/assistant.py
@@ -1,11 +1,20 @@
 import requests
 import json
-from .providers import OpenAIProvider
+from .providers import OpenAIProvider, GroqProvider, LocalTransformersProvider
 from config.settings import settings
 
 class Assistant:
-    def __init__(self, provider=None):
-        self.provider = provider or OpenAIProvider()
+    def __init__(self):
+        provider_name = settings.get_selected_provider()
+        model_name = settings.get_selected_model()
+
+        if provider_name == "groq":
+            self.provider = GroqProvider(model=model_name)
+        elif provider_name == "local_transformers":
+            self.provider = LocalTransformersProvider(model=model_name)
+        else:  # Default to openai
+            self.provider = OpenAIProvider(model=model_name)
+
         self.mcp_server_urls = settings.get_mcp_servers()
         self.tools_info = self._fetch_all_tools()
         self.tool_schemas = [info['schema'] for info in self.tools_info]

--- a/assistant_core/process_manager.py
+++ b/assistant_core/process_manager.py
@@ -1,45 +1,55 @@
 import subprocess
 import shlex
+import atexit
 from config.settings import settings
 
 class ProcessManager:
     def __init__(self):
         self.processes = []
+        atexit.register(self.shutdown)
+
+    def start_process(self, command, args, name="Process"):
+        try:
+            cmd_list = [command] + args
+            print(f"Starting {name}: {' '.join(cmd_list)}")
+            proc = subprocess.Popen(cmd_list, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            self.processes.append(proc)
+            return proc
+        except Exception as e:
+            print(f"Failed to start {name}: {e}")
+            return None
 
     def start_servers(self):
         servers = settings.get_mcp_servers()
         for server in servers:
             if server.get('enabled') and server.get('command'):
-                try:
-                    # Handle args whether they are a string or a list
-                    args_raw = server.get('args')
-                    if isinstance(args_raw, str):
-                        args_list = shlex.split(args_raw)
-                    elif isinstance(args_raw, list):
-                        args_list = args_raw
-                    else:
-                        args_list = []
+                args_raw = server.get('args')
+                if isinstance(args_raw, str):
+                    args_list = shlex.split(args_raw)
+                elif isinstance(args_raw, list):
+                    args_list = args_raw
+                else:
+                    args_list = []
 
-                    command = [server['command']] + args_list
-                    print(f"Starting server '{server['name']}': {' '.join(command)}")
-                    # Use Popen for non-blocking process creation
-                    # Redirect stdout/stderr to DEVNULL to prevent pipe deadlocks
-                    proc = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                    self.processes.append(proc)
-                except Exception as e:
-                    print(f"Failed to start server '{server['name']}': {e}")
+                self.start_process(server['command'], args_list, name=server.get('name', 'MCP Server'))
 
     def shutdown(self):
-        print("Shutting down all managed server processes...")
+        print("Shutting down all managed processes...")
         for proc in self.processes:
-            proc.terminate() # Send SIGTERM
+            if proc.poll() is None:
+                print(f"Terminating process {proc.pid}...")
+                proc.terminate()
 
-        # Optional: wait for processes to terminate gracefully
         for proc in self.processes:
             try:
-                proc.wait(timeout=5)
+                if proc.poll() is None:
+                    proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 print(f"Process {proc.pid} did not terminate gracefully, killing.")
-                proc.kill() # Send SIGKILL
+                proc.kill()
 
+        self.processes = []
         print("Shutdown complete.")
+
+# Global instance
+process_manager = ProcessManager()

--- a/assistant_core/providers.py
+++ b/assistant_core/providers.py
@@ -2,9 +2,14 @@ import openai
 import os
 import json
 import time
+import groq
 
 class BaseProvider:
     def handle_chat(self, user_input: str, tools: list, tool_invoker: callable) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    def get_models(cls):
         raise NotImplementedError()
 
 from config.settings import settings
@@ -64,3 +69,140 @@ class OpenAIProvider(BaseProvider):
         except Exception as e:
             return f"Error calling OpenAI API: {e}"
 
+    @classmethod
+    def get_models(cls):
+        api_key = settings.get_api_key("openai") or os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            return []
+        try:
+            client = openai.OpenAI(api_key=api_key)
+            models = client.models.list()
+            return [model.id for model in models.data]
+        except Exception as e:
+            print(f"Error fetching OpenAI models: {e}")
+            return []
+
+
+class GroqProvider(BaseProvider):
+    def __init__(self, api_key=None, model="llama3-8b-8192"):
+        # Prioritize settings, then environment variable, then direct parameter
+        self.api_key = settings.get_api_key("groq") or os.getenv("GROQ_API_KEY") or api_key
+
+        # The client will be initialized on-demand to avoid errors if key is not set at startup
+        self.client = None
+        self.model = model
+        self.messages = []
+
+    def handle_chat(self, user_input: str, tool_schemas: list, tool_invoker: callable) -> str:
+        if not self.api_key:
+            return "Error: Groq API key is not configured. Please set it via the File -> Manage API Keys menu."
+
+        # Initialize client now that we know we have a key and need to use it
+        if self.client is None:
+            self.client = groq.Groq(api_key=self.api_key)
+
+        return self._handle_chat_completions(user_input, tool_schemas, tool_invoker)
+
+    def _handle_chat_completions(self, user_input: str, tool_schemas: list, tool_invoker: callable) -> str:
+        self.messages.append({"role": "user", "content": user_input})
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=self.messages,
+                tools=tool_schemas,
+                tool_choice="auto",
+            )
+            response_message = response.choices[0].message
+            self.messages.append(response_message)
+
+            if response_message.tool_calls:
+                for tool_call in response_message.tool_calls:
+                    function_name = tool_call.function.name
+                    function_args = json.loads(tool_call.function.arguments)
+                    tool_output = tool_invoker(function_name, function_args)
+
+                    self.messages.append({
+                        "tool_call_id": tool_call.id,
+                        "role": "tool",
+                        "name": function_name,
+                        "content": str(tool_output),
+                    })
+
+                second_response = self.client.chat.completions.create(model=self.model, messages=self.messages)
+                second_response_message = second_response.choices[0].message
+                self.messages.append(second_response_message)
+                return second_response_message.content
+
+            return response_message.content
+        except Exception as e:
+            return f"Error calling Groq API: {e}"
+
+    @classmethod
+    def get_models(cls):
+        api_key = settings.get_api_key("groq") or os.getenv("GROQ_API_KEY")
+        if not api_key:
+            return []
+        try:
+            client = groq.Groq(api_key=api_key)
+            models = client.models.list()
+            return [model.id for model in models.data]
+        except Exception as e:
+            print(f"Error fetching Groq models: {e}")
+            return []
+
+
+class LocalTransformersProvider(BaseProvider):
+    def __init__(self, model="distilbert-base-uncased"):
+        self.client = openai.OpenAI(base_url="http://localhost:8008/v1", api_key="local")
+        self.model = model
+        self.messages = []
+
+    def handle_chat(self, user_input: str, tool_schemas: list, tool_invoker: callable) -> str:
+        return self._handle_chat_completions(user_input, tool_schemas, tool_invoker)
+
+    def _handle_chat_completions(self, user_input: str, tool_schemas: list, tool_invoker: callable) -> str:
+        self.messages.append({"role": "user", "content": user_input})
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=self.messages,
+                tools=tool_schemas,
+                tool_choice="auto",
+            )
+            response_message = response.choices[0].message
+            self.messages.append(response_message)
+
+            if response_message.tool_calls:
+                for tool_call in response_message.tool_calls:
+                    function_name = tool_call.function.name
+                    function_args = json.loads(tool_call.function.arguments)
+                    tool_output = tool_invoker(function_name, function_args)
+
+                    self.messages.append({
+                        "tool_call_id": tool_call.id,
+                        "role": "tool",
+                        "name": function_name,
+                        "content": str(tool_output),
+                    })
+
+                second_response = self.client.chat.completions.create(model=self.model, messages=self.messages)
+                second_response_message = second_response.choices[0].message
+                self.messages.append(second_response_message)
+                return second_response_message.content
+
+            return response_message.content
+        except Exception as e:
+            return f"Error calling Local Transformers API: {e}"
+
+    @classmethod
+    def get_models(cls):
+        try:
+            client = openai.OpenAI(base_url="http://localhost:8008/v1")
+            models = client.models.list()
+            return [model.id for model in models.data]
+        except Exception as e:
+            print(f"Error fetching Local Transformers models: {e}")
+            # Return a default model if the server is not running
+            return ["local-model"]

--- a/config.json
+++ b/config.json
@@ -10,5 +10,7 @@
     ],
     "api_keys": {
         "openai": "sk-..."
-    }
+    },
+    "selected_provider": "openai",
+    "selected_model": "gpt-4"
 }

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,6 +10,8 @@ class Settings:
         if not os.path.exists(self.config_file):
             # Default settings
             return {
+                "selected_provider": "openai",
+                "selected_model": "gpt-4",
                 "mcp_servers": [],
                 "api_keys": {}
             }
@@ -66,6 +68,18 @@ class Settings:
         keys = self.get("api_keys", {})
         keys[provider] = key
         self.set("api_keys", keys)
+
+    def get_selected_provider(self):
+        return self.get("selected_provider", "openai")
+
+    def set_selected_provider(self, provider):
+        self.set("selected_provider", provider)
+
+    def get_selected_model(self):
+        return self.get("selected_model")
+
+    def set_selected_model(self, model):
+        self.set("selected_model", model)
 
 # Global settings instance
 settings = Settings()

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -5,18 +5,34 @@ from config.settings import settings
 class ApiKeysDialog(simpledialog.Dialog):
     def body(self, master):
         self.title("Manage API Keys")
-        tk.Label(master, text="OpenAI API Key:").grid(row=0, sticky="w")
-        self.openai_key_var = tk.StringVar(master)
-        self.openai_key_var.set(settings.get_api_key("openai") or "")
-        self.openai_key_entry = tk.Entry(master, textvariable=self.openai_key_var, width=50)
-        self.openai_key_entry.grid(row=0, column=1, padx=5, pady=5)
-        return self.openai_key_entry
+        self.providers = ["openai", "groq"]  # Providers that require API keys
+
+        tk.Label(master, text="Provider:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        self.provider_var = tk.StringVar(master)
+        self.provider_var.set(self.providers[0])
+        self.provider_menu = ttk.Combobox(master, textvariable=self.provider_var, values=self.providers)
+        self.provider_menu.grid(row=0, column=1, padx=5, pady=5)
+        self.provider_menu.bind("<<ComboboxSelected>>", self.on_provider_select)
+
+        tk.Label(master, text="API Key:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
+        self.api_key_var = tk.StringVar(master)
+        self.api_key_entry = tk.Entry(master, textvariable=self.api_key_var, width=50)
+        self.api_key_entry.grid(row=1, column=1, padx=5, pady=5)
+
+        self.on_provider_select()  # Initial population of the key
+        return self.api_key_entry
+
+    def on_provider_select(self, event=None):
+        provider = self.provider_var.get()
+        api_key = settings.get_api_key(provider) or ""
+        self.api_key_var.set(api_key)
 
     def apply(self):
-        new_key = self.openai_key_var.get().strip()
+        provider = self.provider_var.get()
+        new_key = self.api_key_var.get().strip()
         if new_key:
-            settings.set_api_key("openai", new_key)
-            messagebox.showinfo("Success", "OpenAI API Key saved.", parent=self)
+            settings.set_api_key(provider, new_key)
+            messagebox.showinfo("Success", f"{provider.capitalize()} API Key saved.", parent=self)
 
 class ServerEditorDialog(simpledialog.Dialog):
     def __init__(self, parent, title, server=None):

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,7 +1,13 @@
 import tkinter as tk
+from tkinter import ttk
+import importlib.util
+import subprocess
+import threading
 from assistant_core.assistant import Assistant
+from assistant_core.providers import OpenAIProvider, GroqProvider, LocalTransformersProvider
 from .dialogs import MCPManagerDialog, ApiKeysDialog
 from config.settings import settings
+from assistant_core.process_manager import process_manager
 
 class MainWindow(tk.Tk):
     def __init__(self):
@@ -15,6 +21,13 @@ class MainWindow(tk.Tk):
         # Assistant will be initialized on the first `on_send` call
         self.assistant = None
 
+        self.provider_var = tk.StringVar(self)
+        self.provider_var.set(settings.get_selected_provider())
+        self.model_var = tk.StringVar(self)
+        self.model_var.set(settings.get_selected_model())
+
+        self._update_models_list()
+
     def _create_menu(self):
         self.menu_bar = tk.Menu(self)
 
@@ -26,9 +39,77 @@ class MainWindow(tk.Tk):
         file_menu.add_command(label="Exit", command=self.quit)
         self.menu_bar.add_cascade(label="File", menu=file_menu)
 
+        # Provider Menu
+        provider_menu = tk.Menu(self.menu_bar, tearoff=0)
+        provider_menu.add_radiobutton(label="OpenAI", variable=self.provider_var, value="openai", command=self._on_provider_changed)
+        provider_menu.add_radiobutton(label="Groq", variable=self.provider_var, value="groq", command=self._on_provider_changed)
+        provider_menu.add_radiobutton(label="Local Transformers", variable=self.provider_var, value="local_transformers", command=self._on_provider_changed)
+        self.menu_bar.add_cascade(label="Provider", menu=provider_menu)
+
         self.config(menu=self.menu_bar)
 
+    def _update_models_list(self):
+        provider_name = self.provider_var.get()
+
+        if provider_name == "openai":
+            models = OpenAIProvider.get_models()
+        elif provider_name == "groq":
+            models = GroqProvider.get_models()
+        elif provider_name == "local_transformers":
+            models = LocalTransformersProvider.get_models()
+        else:
+            models = []
+
+        self.model_menu['values'] = models
+        if models:
+            current_model = self.model_var.get()
+            if current_model not in models:
+                self.model_var.set(models[0])
+                settings.set_selected_model(models[0])
+        else:
+            self.model_var.set("")
+
+    def _on_provider_changed(self):
+        provider = self.provider_var.get()
+        settings.set_selected_provider(provider)
+        self._update_models_list()
+        print(f"Switched to {provider} provider.")
+
+        if provider == "local_transformers":
+            threading.Thread(target=self._setup_local_transformers, daemon=True).start()
+
+    def _setup_local_transformers(self):
+        if importlib.util.find_spec("transformers") is None:
+            print("transformers library not found. Installing...")
+            self.output_text.insert(tk.END, "> Assistant: Installing transformers library. This may take a moment...\n")
+            self.output_text.update_idletasks()
+
+            try:
+                subprocess.check_call(["uv", "pip", "install", "git+https://github.com/huggingface/transformers.git"])
+                self.output_text.insert(tk.END, "> Assistant: transformers library installed successfully.\n")
+            except subprocess.CalledProcessError as e:
+                self.output_text.insert(tk.END, f"> Assistant: Error installing transformers: {e}\n")
+                return
+
+        print("Starting local transformers server...")
+        self.output_text.insert(tk.END, "> Assistant: Starting local transformers server...\n")
+        process_manager.start_process("uv", ["run", "python", "-m", "transformers.commands.serve", "local", "--port", "8008"], name="Transformers Server")
+
+    def _on_model_changed(self, event=None):
+        model = self.model_var.get()
+        settings.set_selected_model(model)
+        print(f"Switched to model {model}")
+
     def _create_widgets(self):
+        # Top frame for provider and model selection
+        top_frame = tk.Frame(self)
+        top_frame.pack(fill="x", padx=10, pady=5)
+
+        tk.Label(top_frame, text="Model:").pack(side="left")
+        self.model_menu = ttk.Combobox(top_frame, textvariable=self.model_var)
+        self.model_menu.pack(side="left", padx=5)
+        self.model_menu.bind("<<ComboboxSelected>>", self._on_model_changed)
+
         # Main chat widgets
         self.input_text = tk.Text(self, height=4)
         self.input_text.pack(fill="x", padx=10)

--- a/main.py
+++ b/main.py
@@ -1,14 +1,9 @@
-import atexit
 from gui.main_window import MainWindow
-from assistant_core.process_manager import ProcessManager
+from assistant_core.process_manager import process_manager
 
 def main():
-    # Initialize and start MCP server processes
-    process_manager = ProcessManager()
+    # Start MCP server processes
     process_manager.start_servers()
-
-    # Register shutdown hook to terminate servers on exit
-    atexit.register(process_manager.shutdown)
 
     # Run the GUI
     app = MainWindow()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 openai
+groq
 tk
 Flask
 requests

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+# Add the root directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from assistant_core.assistant import Assistant
+from config.settings import settings
+from assistant_core.process_manager import process_manager
+
+class TestAssistant(unittest.TestCase):
+
+    def setUp(self):
+        # Reset settings to default before each test
+        settings.settings = settings._load_settings()
+        # Clear any running processes
+        process_manager.shutdown()
+
+    @patch('assistant_core.providers.OpenAIProvider.handle_chat')
+    def test_openai_provider(self, mock_handle_chat):
+        settings.set_selected_provider("openai")
+        settings.set_selected_model("gpt-4")
+        assistant = Assistant()
+        assistant.handle_command("test input")
+        self.assertEqual(assistant.provider.__class__.__name__, "OpenAIProvider")
+        self.assertEqual(assistant.provider.model, "gpt-4")
+        mock_handle_chat.assert_called_once_with("test input", assistant.tool_schemas, assistant._invoke_tool)
+
+    @patch('assistant_core.providers.GroqProvider.handle_chat')
+    def test_groq_provider(self, mock_handle_chat):
+        settings.set_selected_provider("groq")
+        settings.set_selected_model("llama3-8b-8192")
+        assistant = Assistant()
+        assistant.handle_command("test input")
+        self.assertEqual(assistant.provider.__class__.__name__, "GroqProvider")
+        self.assertEqual(assistant.provider.model, "llama3-8b-8192")
+        mock_handle_chat.assert_called_once_with("test input", assistant.tool_schemas, assistant._invoke_tool)
+
+    @patch('assistant_core.process_manager.ProcessManager.start_process')
+    @patch('assistant_core.providers.LocalTransformersProvider.handle_chat')
+    def test_local_transformers_provider(self, mock_handle_chat, mock_start_process):
+        settings.set_selected_provider("local_transformers")
+        settings.set_selected_model("local-model")
+
+        # This is a bit tricky to test without a real GUI.
+        # The setup is triggered by the GUI's _on_provider_changed method.
+        # We will simulate this by calling the setup method directly.
+        # To do that, we would need to instantiate the MainWindow, which we can't.
+        # So, we will test the assistant's behavior when the provider is selected.
+
+        assistant = Assistant()
+        assistant.handle_command("test input")
+
+        self.assertEqual(assistant.provider.__class__.__name__, "LocalTransformersProvider")
+        self.assertEqual(assistant.provider.model, "local-model")
+        mock_handle_chat.assert_called_once_with("test input", assistant.tool_schemas, assistant._invoke_tool)
+
+    def tearDown(self):
+        # Clean up any processes that might have been started
+        process_manager.shutdown()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a new feature that allows you to select an LLM provider from a list of options: OpenAI, Groq, and local transformers.

Key changes:
- Added a "Provider" menu to the GUI to switch between providers.
- Implemented a generalized API key management dialog for multiple providers.
- Created new provider classes for Groq and local transformers.
- Added logic to fetch and display available models for the selected provider.
- Implemented a setup process for the local transformers provider, which includes automatic installation of the `transformers` library and launching the `transformers serve` command.
- Refactored the `ProcessManager` to handle background processes more generically.
- Added unit tests to verify the new functionality.